### PR TITLE
Tweak documentation and fix newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ Solution to patch vGPU_Unlock into Nvidia Driver
    fi
    ```
    change the ID's ```0x1E30 0x12BA 0x1E84 0x0000``` to a matching set
-   here:
-   ```0x1E30 0x12BA``` Quadro RTX 6000 to
-   ```0x1E84 0x0000``` RTX 2070 Super
+   here:  
+   ```0x1E30 0x12BA``` Quadro RTX 6000 to  
+   ```0x1E84 0x0000``` RTX 2070 Super  
 
-   E.g. P40 to 1080Ti:
-   ```0x1B38 0x11D9``` Tesla P40 to
-   ```0x1B06 0x120F``` 1080Ti
-   the new vcfgclone line in this example:
+   E.g. P40 to 1080Ti:  
+   ```0x1B38 0x11D9``` Tesla P40 to  
+   ```0x1B06 0x120F``` 1080Ti  
+   the new vcfgclone line in this example:  
    ```vcfgclone ${TARGET}/vgpuConfig.xml 0x1B38 0x11D9 0x1B06 0x120F```
 
-3. Run one of these commands:
-   ``` ./patch.sh general-merge ``` creates a merge vgpu-kvm with consumer driver
-   ``` ./patch.sh vgpu-kvm ``` just patch the vgpu-kvm driver (in case you use secondary gpu) #proxmox
-   ``` ./patch.sh grid-merge ``` creates a merge vgpu-kvm with VGPU guest driver
-   ``` ./patch.sh grid ``` 
-   ``` ./patch.sh general ``` 
-   ``` ./patch.sh vcfg ``` 
+3. Run one of these commands:  
+   ``` ./patch.sh general-merge ``` creates a merge vgpu-kvm with consumer driver  
+   ``` ./patch.sh vgpu-kvm ``` just patch the vgpu-kvm driver (in case you use secondary gpu) #proxmox  
+   ``` ./patch.sh grid-merge ``` creates a merge vgpu-kvm with VGPU guest driver  
+   ``` ./patch.sh grid ```  
+   ``` ./patch.sh general ```  
+   ``` ./patch.sh vcfg ```
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -17,24 +17,24 @@ Solution to patch vGPU_Unlock into Nvidia Driver
        vcfgclone ${TARGET}/vgpuConfig.xml 0x1E30 0x12BA 0x1E84 0x0000
    fi
    ```
-   change the ID's ```0x1E30 0x12BA 0x1E84 0x0000``` to a matching set
+   change the ID's `0x1E30 0x12BA 0x1E84 0x0000` to a matching set
    here:  
-   ```0x1E30 0x12BA``` Quadro RTX 6000 to  
-   ```0x1E84 0x0000``` RTX 2070 Super  
+   `0x1E30 0x12BA` Quadro RTX 6000 to  
+   `0x1E84 0x0000` RTX 2070 Super  
 
    E.g. P40 to 1080Ti:  
-   ```0x1B38 0x11D9``` Tesla P40 to  
-   ```0x1B06 0x120F``` 1080Ti  
+   `0x1B38 0x11D9` Tesla P40 to  
+   `0x1B06 0x120F` 1080Ti  
    the new vcfgclone line in this example:  
-   ```vcfgclone ${TARGET}/vgpuConfig.xml 0x1B38 0x11D9 0x1B06 0x120F```
+   `vcfgclone ${TARGET}/vgpuConfig.xml 0x1B38 0x11D9 0x1B06 0x120F`
 
 3. Run one of these commands:  
-   ``` ./patch.sh general-merge ``` creates a merge vgpu-kvm with consumer driver  
-   ``` ./patch.sh vgpu-kvm ``` just patch the vgpu-kvm driver (in case you use secondary gpu) #proxmox  
-   ``` ./patch.sh grid-merge ``` creates a merge vgpu-kvm with VGPU guest driver  
-   ``` ./patch.sh grid ```  
-   ``` ./patch.sh general ```  
-   ``` ./patch.sh vcfg ```
+   `./patch.sh general-merge` creates a merge vgpu-kvm with consumer driver  
+   `./patch.sh vgpu-kvm` just patch the vgpu-kvm driver (in case you use secondary gpu) #proxmox  
+   `./patch.sh grid-merge` creates a merge vgpu-kvm with VGPU guest driver  
+   `./patch.sh grid`  
+   `./patch.sh general`  
+   `./patch.sh vcfg`
 
 ## Changelog
 
@@ -47,7 +47,7 @@ Solution to patch vGPU_Unlock into Nvidia Driver
 
 ### Other Options 
 
-```--repack ``` option that can be used to create unlocked/patched .run file (usually not necessary as you can simply start nvidia-installer from the directory).
+`--repack` option that can be used to create unlocked/patched .run file (usually not necessary as you can simply start nvidia-installer from the directory).
 
 ### Credits
 - Thanks to the discord user @mbuchel for the experimental patches

--- a/README.md
+++ b/README.md
@@ -4,38 +4,37 @@ Solution to patch vGPU_Unlock into Nvidia Driver
 ## Usage
 
 1. pre-downloaded original .run files:
-
-| Name | Version | Links |
-| --- | ----------- | ----------- |
-| General | NVIDIA-Linux-x86_64-510.85.02 | [Nvidia Download](https://download.nvidia.com/XFree86/Linux-x86_64/510.85.02/NVIDIA-Linux-x86_64-510.85.02.run)  |
-| VGPU | VIDIA-Linux-x86_64-510.85.03-vgpu-kvm| [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198), [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
-| GRID | NVIDIA-Linux-x86_64-510.85.02-grid | [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198) [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
+   | Name | Version | Links |
+   | --- | ----------- | ----------- |
+   | General | NVIDIA-Linux-x86_64-510.85.02 | [Nvidia Download](https://download.nvidia.com/XFree86/Linux-x86_64/510.85.02/NVIDIA-Linux-x86_64-510.85.02.run)  |
+   | VGPU | VIDIA-Linux-x86_64-510.85.03-vgpu-kvm| [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198), [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
+   | GRID | NVIDIA-Linux-x86_64-510.85.02-grid | [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198) [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
 
 2. Setup Spoofing - edit patch.sh file and search 
-```
-if $DO_VGPU; then
-    applypatch ${TARGET} vcfg-testing.patch
-    vcfgclone ${TARGET}/vgpuConfig.xml 0x1E30 0x12BA 0x1E84 0x0000
-fi
-```
-change the ID's ```0x1E30 0x12BA 0x1E84 0x0000``` to a matching set
-here:
-```0x1E30 0x12BA``` Quadro RTX 6000 to
-```0x1E84 0x0000``` RTX 2070 Super
+   ```
+   if $DO_VGPU; then
+       applypatch ${TARGET} vcfg-testing.patch
+       vcfgclone ${TARGET}/vgpuConfig.xml 0x1E30 0x12BA 0x1E84 0x0000
+   fi
+   ```
+   change the ID's ```0x1E30 0x12BA 0x1E84 0x0000``` to a matching set
+   here:
+   ```0x1E30 0x12BA``` Quadro RTX 6000 to
+   ```0x1E84 0x0000``` RTX 2070 Super
 
-E.g. P40 to 1080Ti:
-```0x1B38 0x11D9``` Tesla P40 to
-```0x1B06 0x120F``` 1080Ti
-the new vcfgclone line in this example:
-```vcfgclone ${TARGET}/vgpuConfig.xml 0x1B38 0x11D9 0x1B06 0x120F```
+   E.g. P40 to 1080Ti:
+   ```0x1B38 0x11D9``` Tesla P40 to
+   ```0x1B06 0x120F``` 1080Ti
+   the new vcfgclone line in this example:
+   ```vcfgclone ${TARGET}/vgpuConfig.xml 0x1B38 0x11D9 0x1B06 0x120F```
 
 3. Run one of these commands:
-``` ./patch.sh general-merge ``` creates a merge vgpu-kvm with consumer driver
-``` ./patch.sh vgpu-kvm ``` just patch the vgpu-kvm driver (in case you use secondary gpu) #proxmox
-``` ./patch.sh grid-merge ``` creates a merge vgpu-kvm with VGPU guest driver
-``` ./patch.sh grid ``` 
-``` ./patch.sh general ``` 
-``` ./patch.sh vcfg ``` 
+   ``` ./patch.sh general-merge ``` creates a merge vgpu-kvm with consumer driver
+   ``` ./patch.sh vgpu-kvm ``` just patch the vgpu-kvm driver (in case you use secondary gpu) #proxmox
+   ``` ./patch.sh grid-merge ``` creates a merge vgpu-kvm with VGPU guest driver
+   ``` ./patch.sh grid ``` 
+   ``` ./patch.sh general ``` 
+   ``` ./patch.sh vcfg ``` 
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Solution to patch vGPU_Unlock into Nvidia Driver
 
 ## Usage
 
-1. pre-downloaded original .run files:
+1. pre-downloaded original `.run` files:
    | Name | Version | Links |
    | --- | ----------- | ----------- |
    | General | NVIDIA-Linux-x86_64-510.85.02 | [Nvidia Download](https://download.nvidia.com/XFree86/Linux-x86_64/510.85.02/NVIDIA-Linux-x86_64-510.85.02.run)  |
    | VGPU | VIDIA-Linux-x86_64-510.85.03-vgpu-kvm| [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198), [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
    | GRID | NVIDIA-Linux-x86_64-510.85.02-grid | [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198) [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
 
-2. Setup Spoofing - edit patch.sh file and search 
+2. Setup Spoofing - edit `patch.sh` file and search
    ```
    if $DO_VGPU; then
        applypatch ${TARGET} vcfg-testing.patch
@@ -38,7 +38,7 @@ Solution to patch vGPU_Unlock into Nvidia Driver
 
 ## Changelog
 
-- cudahost=1 nvidia module option of merged driver now works with all versions, enables also raytracing on host
+- `cudahost=1` nvidia module option of merged driver now works with all versions, enables also raytracing on host
 - multiple fixes and tuning in the default profiles for rtx 2070+
 - simplified patching focusing only on vgpu kvm blob, split the patch for merged driver extension
 - supports setup of general-merge converting grid variant to general in case general run file is not available
@@ -47,7 +47,7 @@ Solution to patch vGPU_Unlock into Nvidia Driver
 
 ### Other Options 
 
-`--repack` option that can be used to create unlocked/patched .run file (usually not necessary as you can simply start nvidia-installer from the directory).
+`--repack` option that can be used to create unlocked/patched `.run` file (usually not necessary as you can simply start nvidia-installer from the directory).
 
 ### Credits
 - Thanks to the discord user @mbuchel for the experimental patches

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Solution to patch vGPU_Unlock into Nvidia Driver
    | --- | ----------- | ----------- |
    | General | NVIDIA-Linux-x86_64-510.85.02 | [Nvidia Download](https://download.nvidia.com/XFree86/Linux-x86_64/510.85.02/NVIDIA-Linux-x86_64-510.85.02.run)  |
    | VGPU | VIDIA-Linux-x86_64-510.85.03-vgpu-kvm| [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198), [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
-   | GRID | NVIDIA-Linux-x86_64-510.85.02-grid | [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198) [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
+   | GRID | NVIDIA-Linux-x86_64-510.85.02-grid | [Nvidia Download](https://enterprise-support.nvidia.com/s/login/?startURL=%2Fs%2F%3Ft%3D1657093205198), [Google Drive](https://drive.google.com/drive/folders/1YwGqtiginXXjSndBBCifTt6SfpVLR9Yx?usp=sharing), [GitHub](https://github.com/VGPU-Community-Drivers/NV-VGPU-Driver/releases/tag/1.0.2) |
 
 2. Setup Spoofing - edit `patch.sh` file and search
    ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Solution to patch vGPU_Unlock into Nvidia Driver
 
 ## Usage
 
-1. pre-downloaded original `.run` files:
+1. Pre-download original `.run` files:
    | Name | Version | Links |
    | --- | ----------- | ----------- |
    | General | NVIDIA-Linux-x86_64-510.85.02 | [Nvidia Download](https://download.nvidia.com/XFree86/Linux-x86_64/510.85.02/NVIDIA-Linux-x86_64-510.85.02.run)  |
@@ -17,7 +17,7 @@ Solution to patch vGPU_Unlock into Nvidia Driver
        vcfgclone ${TARGET}/vgpuConfig.xml 0x1E30 0x12BA 0x1E84 0x0000
    fi
    ```
-   change the ID's `0x1E30 0x12BA 0x1E84 0x0000` to a matching set
+   Change the ID's `0x1E30 0x12BA 0x1E84 0x0000` to a matching set
    here:  
    `0x1E30 0x12BA` Quadro RTX 6000 to  
    `0x1E84 0x0000` RTX 2070 Super  
@@ -25,7 +25,7 @@ Solution to patch vGPU_Unlock into Nvidia Driver
    E.g. P40 to 1080Ti:  
    `0x1B38 0x11D9` Tesla P40 to  
    `0x1B06 0x120F` 1080Ti  
-   the new vcfgclone line in this example:  
+   The new vcfgclone line in this example:  
    `vcfgclone ${TARGET}/vgpuConfig.xml 0x1B38 0x11D9 0x1B06 0x120F`
 
 3. Run one of these commands:  


### PR DESCRIPTION
In order for the Markdown render to look like its source, newline-wise, I added double spaces at end of specific lines.
Tabulations were also added to the content of ordered list in order to align with the number.
Other tweaks here and there, like inline code blocks.