### PR TITLE
feat(patch.sh): add support for nvidia-container-toolkit for merged drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The update was also tested on 5.10 Kernel!
 
 ## Changelog
 
+- added `--docker-hack` option to fix `nvidia-docker-toolkit` not being able to detect the correct libraries
 - `cudahost=1` nvidia module option of merged driver now works with all versions, enables also raytracing on host
 - multiple fixes and tuning in the default profiles for rtx 2070+
 - simplified patching focusing only on vgpu kvm blob, split the patch for merged driver extension
@@ -55,6 +56,7 @@ The update was also tested on 5.10 Kernel!
 ### Other Options 
 
 `--repack` option that can be used to create unlocked/patched `.run` file (usually not necessary as you can simply start nvidia-installer from the directory).
+`--docker-hack` option to patch the driver version to make it compatible with the `nvidia-docker-toolkit` so vGPU functionality and Docker can be used simultaneously with a merged driver
 
 ### Credits
 - Thanks to the discord user @mbuchel for the experimental patches


### PR DESCRIPTION
This hack patches and renames all files that have a version mismatch with VER_TARGET when the arg `--docker-hack` is supplied.

The reason to do this is because the nvidia-container-toolkit specifically checks for the driver version when linking nvidia libraries into the container. 

See [here](https://gitlab.com/nvidia/container-toolkit/libnvidia-container/-/blob/main/src/nvc_info.c#L176), `rv` returns the version of the kvm-gpu driver which is currently `525.60.12` but the merged drivers libs all use the suffix `525.60.13` from the grid driver or `525.60.11` from the general driver.
When executing `nvidia-container-cli -k -d /dev/tty info` the log shows that the toolkit skips the libraries it is actually supposed to link, because the detected version mismatches:
```
...
I1229 23:50:08.540565 38248 nvc_info.c:176] skipping /usr/lib/libnvidia-ml.so.525.60.13
...
```

This fails because the merged driver is composed of two different versions so the toolkit thinks that the required libraries are missing.

With the implemented hack all strings containing the vgpu-kvm driver version are replaced with the target version from either the extracted grid or general driver, that way the container toolkit can detect the libraries it needs to link.

I named it `docker-hack` because it hides the true version of the kvm-gpu driver. Though technically it should fix other applications that behave the same way as the nvidia-docker-toolkit so maybe it might be implemented as default?

~I also used `bbe` to patch the binaries, if someone can tell me a surefire way to transform the strings from `VER_BLOB` and `VER_TARGET` into proper hex decimals so I can patch the binaries with `sed`, I'd be glad to throw `bbe` out.~

**Edit:** I completely patched out the usage of bbe and rename so now it should work without installing any extra utilities. Now I use sed & mv to rename files and printf magic to convert the versions to hex so I can use sed for binary patches.

Discord history:
https://discord.com/channels/829786927829745685/830520513834516530/1058187278477959219
https://discord.com/channels/829786927829745685/830520513834516530/1058401927613915226
https://discord.com/channels/829786927829745685/830520513834516530/1071759333043478569